### PR TITLE
Add more cli options using gumdrop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,7 @@ dependencies = [
  "fps_ticker",
  "futures",
  "generational-arena",
+ "gumdrop",
  "image",
  "imgui",
  "imgui-smithay-renderer",
@@ -56,6 +57,7 @@ dependencies = [
  "slog-stream",
  "slog-term",
  "smithay",
+ "strum",
  "thiserror",
  "x11rb",
  "xcursor",
@@ -666,10 +668,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "gumdrop"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46571f5d540478cf70d2a42dd0d6d8e9f4b9cc7531544b93311e657b86568a0b"
+dependencies = [
+ "gumdrop_derive",
+]
+
+[[package]]
+name = "gumdrop_derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915ef07c710d84733522461de2a734d4d62a3fd39a4d4f404c2f385ef8618d05"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -1556,6 +1587,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "strum"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cae14b91c7d11c9a851d3fbc80a963198998c2a64eec840477fa92d8ce9b70bb"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bb0dc7ee9c15cea6199cde9a127fa16a4c5819af85395457ad72d68edc85a38"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1664,6 +1717,12 @@ dependencies = [
  "libudev-sys",
  "pkg-config",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,9 @@ lazy_static = "1.4.0"
 
 chrono = "0.4"
 
+gumdrop = "0.8.0"
+strum = { version = "0.23", features = ["derive"] }
+
 [dependencies.smithay]
 # git = "https://github.com/Smithay/smithay.git"
 git = "https://github.com/PolyMeilex/smithay.git"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,41 @@
+use std::path::PathBuf;
+
+use gumdrop::Options;
+
+use strum::EnumString;
+
+#[derive(Debug, EnumString)]
+pub enum Backend {
+    #[strum(serialize = "auto")]
+    Auto,
+    #[strum(serialize = "x11")]
+    X11,
+    #[strum(serialize = "winit")]
+    Winit,
+    #[strum(serialize = "udev")]
+    Udev,
+}
+
+#[derive(Debug, Options)]
+pub struct AnodiumOptions {
+    #[options(help = "print help message")]
+    help: bool,
+
+    #[options(
+        help = "selected backend: auto, x11, winit, udev",
+        meta = "BACKEND",
+        default = "auto"
+    )]
+    pub backend: Backend,
+
+    #[options(
+        help = "use provided path as rhai config script",
+        meta = "PATH",
+        default = "./config.rhai"
+    )]
+    pub config: PathBuf,
+}
+
+pub fn get_anodium_options() -> AnodiumOptions {
+    AnodiumOptions::parse_args_default_or_exit()
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,5 +1,6 @@
 use std::cell::RefCell;
 use std::collections::HashSet;
+use std::path::PathBuf;
 use std::rc::Rc;
 
 use rhai::{Dynamic, Engine, EvalAltResult, FnPtr, FuncArgs, Scope, AST};
@@ -43,6 +44,7 @@ impl ConfigVM {
         event_sender: Sender<ConfigEvent>,
         output_map: OutputMap,
         loop_handle: LoopHandle<'static, Anodium>,
+        config: PathBuf,
     ) -> Result<ConfigVM, Box<EvalAltResult>> {
         let mut engine = Engine::new();
         engine.set_max_expr_depths(0, 0);
@@ -63,7 +65,7 @@ impl ConfigVM {
             loop_handle,
         );
 
-        let ast = engine.compile_file("config.rhai".into())?;
+        let ast = engine.compile_file(config)?;
 
         engine.eval_ast_with_scope(&mut scope, &ast)?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,8 @@ mod state;
 mod backend_handler;
 mod shell_handler;
 
+mod cli;
+
 use config::outputs::shell::logger::ShellDrain;
 use state::Anodium;
 
@@ -39,6 +41,8 @@ use smithay::reexports::calloop::EventLoop;
 use std::sync::atomic::Ordering;
 
 fn main() {
+    let options = cli::get_anodium_options();
+
     std::env::set_var("RUST_LOG", "trace,smithay=error");
     let terminal_drain = slog_async::Async::default(slog_envlogger::new(
         slog_term::CompactFormat::new(slog_term::TermDecorator::new().stderr().build())
@@ -65,13 +69,12 @@ fn main() {
 
     let mut event_loop = EventLoop::try_new().unwrap();
 
-    let anodium = framework::backend::auto(&mut event_loop);
+    let anodium = framework::backend::auto(&mut event_loop, options);
     let anodium = anodium.expect("Could not create a backend!");
     run_loop(anodium, event_loop);
 }
 
 fn run_loop(mut state: Anodium, mut event_loop: EventLoop<'static, Anodium>) {
-    trace!("trace test");
     let signal = event_loop.get_signal();
     event_loop
         .run(None, &mut state, |state| {

--- a/src/state.rs
+++ b/src/state.rs
@@ -29,6 +29,7 @@ use smithay::{
 use smithay::xwayland::{XWayland, XWaylandEvent};
 
 use crate::{
+    cli::AnodiumOptions,
     config::{eventloop::ConfigEvent, ConfigVM},
     framework::backend::BackendRequest,
     framework::shell::ShellManager,
@@ -65,6 +66,8 @@ pub struct Anodium {
 
     pub seat_name: String,
     pub seat: Seat,
+
+    pub options: AnodiumOptions,
 
     pub start_time: std::time::Instant,
     last_update: Instant,
@@ -213,6 +216,7 @@ impl Anodium {
         handle: LoopHandle<'static, Self>,
         seat_name: String,
         backend_tx: Sender<BackendRequest>,
+        options: AnodiumOptions,
     ) -> Self {
         let log = slog_scope::logger();
 
@@ -240,7 +244,13 @@ impl Anodium {
         let config_tx = Self::init_config_channel(&handle);
         let output_map = OutputMap::new(config_tx.clone());
 
-        let config = ConfigVM::new(config_tx.clone(), output_map.clone(), handle.clone()).unwrap();
+        let config = ConfigVM::new(
+            config_tx.clone(),
+            output_map.clone(),
+            handle.clone(),
+            options.config.clone(),
+        )
+        .unwrap();
 
         Self {
             handle,
@@ -265,6 +275,8 @@ impl Anodium {
 
             seat_name,
             seat,
+
+            options,
 
             start_time: Instant::now(),
             last_update: Instant::now(),


### PR DESCRIPTION
This PR add extra CLI options:
```
Optional arguments:
  -h, --help             print help message
  -b, --backend BACKEND  selected backend: auto, x11, winit, udev (default: auto)
  -c, --config PATH      use provided path as rhai config script (default: ./config.rhai)
  ```
  