### PR TITLE
Replace imgui with egui in shells

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,7 +53,7 @@ dependencies = [
  "cgmath",
  "chrono",
  "derivative",
- "egui_demo_lib",
+ "egui",
  "fps_ticker",
  "futures",
  "generational-arena",
@@ -209,12 +209,10 @@ version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
 dependencies = [
- "js-sys",
  "libc",
  "num-integer",
  "num-traits",
  "time",
- "wasm-bindgen",
  "winapi",
 ]
 
@@ -529,44 +527,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "egui_demo_lib"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad907b870f83da0fbf9532967b0d22d19edf78d1b7d5aa83d0e95a79a632600b"
-dependencies = [
- "chrono",
- "egui",
- "enum-map",
- "epi",
- "unicode_names2",
-]
-
-[[package]]
 name = "emath"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55673de2eb96660dde25ba7b2d36a7054beead1a2bec74dcfd5eb05a1e1ba76d"
-
-[[package]]
-name = "enum-map"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e893a7ba6116821058dec84a6fb14fb2a97cd8ce5fd0f85d5a4e760ecd7329d9"
-dependencies = [
- "enum-map-derive",
- "serde",
-]
-
-[[package]]
-name = "enum-map-derive"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84278eae0af6e34ff6c1db44c11634a694aafac559ff3080e4db4e4ac35907aa"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "epaint"
@@ -579,15 +543,6 @@ dependencies = [
  "atomic_refcell",
  "emath",
  "nohash-hasher",
-]
-
-[[package]]
-name = "epi"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ae4ce3271febeacc5b4afbd77e500316c6ba316561067acbdddf0c14268a7c"
-dependencies = [
- "egui",
 ]
 
 [[package]]
@@ -1873,12 +1828,6 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
-
-[[package]]
-name = "unicode_names2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87d6678d7916394abad0d4b19df4d3802e1fd84abd7d701f39b75ee71b9e8cf1"
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,7 +60,6 @@ dependencies = [
  "gumdrop",
  "image",
  "imgui",
- "imgui-smithay-renderer",
  "input",
  "lazy_static",
  "rand",
@@ -807,16 +806,6 @@ dependencies = [
  "bitflags",
  "imgui-sys",
  "parking_lot",
-]
-
-[[package]]
-name = "imgui-smithay-renderer"
-version = "0.1.0"
-dependencies = [
- "cgmath",
- "imgui",
- "memoffset",
- "smithay",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,6 +52,8 @@ dependencies = [
  "calloop",
  "cgmath",
  "chrono",
+ "derivative",
+ "egui_demo_lib",
  "fps_ticker",
  "futures",
  "generational-arena",
@@ -205,10 +207,12 @@ version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
 dependencies = [
+ "js-sys",
  "libc",
  "num-integer",
  "num-traits",
  "time",
+ "wasm-bindgen",
  "winapi",
 ]
 
@@ -423,6 +427,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -512,10 +527,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "egui_demo_lib"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad907b870f83da0fbf9532967b0d22d19edf78d1b7d5aa83d0e95a79a632600b"
+dependencies = [
+ "chrono",
+ "egui",
+ "enum-map",
+ "epi",
+ "unicode_names2",
+]
+
+[[package]]
 name = "emath"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55673de2eb96660dde25ba7b2d36a7054beead1a2bec74dcfd5eb05a1e1ba76d"
+
+[[package]]
+name = "enum-map"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e893a7ba6116821058dec84a6fb14fb2a97cd8ce5fd0f85d5a4e760ecd7329d9"
+dependencies = [
+ "enum-map-derive",
+ "serde",
+]
+
+[[package]]
+name = "enum-map-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84278eae0af6e34ff6c1db44c11634a694aafac559ff3080e4db4e4ac35907aa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "epaint"
@@ -528,6 +577,15 @@ dependencies = [
  "atomic_refcell",
  "emath",
  "nohash-hasher",
+]
+
+[[package]]
+name = "epi"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ae4ce3271febeacc5b4afbd77e500316c6ba316561067acbdddf0c14268a7c"
+dependencies = [
+ "egui",
 ]
 
 [[package]]
@@ -1756,6 +1814,12 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "unicode_names2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87d6678d7916394abad0d4b19df4d3802e1fd84abd7d701f39b75ee71b9e8cf1"
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,22 @@
 version = 3
 
 [[package]]
+name = "ab_glyph"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61caed9aec6daeee1ea38ccf5fb225e4f96c1eeead1b4a5c267324a63cf02326"
+dependencies = [
+ "ab_glyph_rasterizer",
+ "owned_ttf_parser",
+]
+
+[[package]]
+name = "ab_glyph_rasterizer"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13739d7177fbd22bb0ed28badfff9f372f8bef46c863db4e1c6248f6b223b6e"
+
+[[package]]
 name = "adler32"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -56,6 +72,7 @@ dependencies = [
  "slog-stream",
  "slog-term",
  "smithay",
+ "smithay-egui",
  "thiserror",
  "x11rb",
  "xcursor",
@@ -82,6 +99,12 @@ name = "arc-swap"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5d78ce20460b82d3fa150275ed9d55e21064fc7951177baacf86a145c4a4b1f"
+
+[[package]]
+name = "atomic_refcell"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b5e5f48b927f04e952dedc932f31995a65a0bf65ec971c74436e51bf6e970d"
 
 [[package]]
 name = "atty"
@@ -475,6 +498,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5f45fcdd3b2f3c13fadea11b2a4eda2023e7de55021da039eac4a3beecfe91c"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "egui"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c733356eb5f1139fdeedc370c00e9ea689c5d9120502c43925285bc7249a333"
+dependencies = [
+ "ahash",
+ "epaint",
+ "nohash-hasher",
+]
+
+[[package]]
+name = "emath"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55673de2eb96660dde25ba7b2d36a7054beead1a2bec74dcfd5eb05a1e1ba76d"
+
+[[package]]
+name = "epaint"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adfd9296f7f92902e41c0e8e5deca6d2fb29f289c86d03a01ea01bd7498316c2"
+dependencies = [
+ "ab_glyph",
+ "ahash",
+ "atomic_refcell",
+ "emath",
+ "nohash-hasher",
 ]
 
 [[package]]
@@ -992,6 +1045,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
 name = "nom"
 version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1087,6 +1146,15 @@ name = "once_cell"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
+
+[[package]]
+name = "owned_ttf_parser"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ef05f2882a8b3e7acc10c153ade2631f7bfc8ce00d2bf3fb8f4e9d2ae6ea5c3"
+dependencies = [
+ "ttf-parser",
+]
 
 [[package]]
 name = "parking_lot"
@@ -1544,6 +1612,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "smithay-egui"
+version = "0.1.0"
+source = "git+https://github.com/Smithay/smithay-egui#baa131d77b2fc2e3c2e87e881bba3ee18b315d14"
+dependencies = [
+ "egui",
+ "lazy_static",
+ "memoffset",
+ "slog 2.7.0",
+ "smithay",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1653,6 +1733,12 @@ checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "ttf-parser"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ccbe8381883510b6a2d8f1e32905bddd178c11caef8083086d0c0c9ab0ac281"
 
 [[package]]
 name = "udev"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1619,7 +1619,7 @@ dependencies = [
 [[package]]
 name = "smithay-egui"
 version = "0.1.0"
-source = "git+https://github.com/dragonnn/smithay-egui#1a8a03304eb8fdd5d770144de59f4ea9c0b94d56"
+source = "git+https://github.com/dragonnn/smithay-egui?rev=1a8a03304eb8fdd5d770144de59f4ea9c0b94d56#1a8a03304eb8fdd5d770144de59f4ea9c0b94d56"
 dependencies = [
  "egui",
  "lazy_static",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,7 +59,6 @@ dependencies = [
  "generational-arena",
  "gumdrop",
  "image",
- "imgui",
  "input",
  "lazy_static",
  "rand",
@@ -195,12 +194,6 @@ dependencies = [
  "approx",
  "num-traits",
 ]
-
-[[package]]
-name = "chlorine"
-version = "1.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75476fe966a8af7c0ceae2a3e514afa87d4451741fcdfab8bfaa07ad301842ec"
 
 [[package]]
 name = "chrono"
@@ -795,27 +788,6 @@ dependencies = [
  "num-rational",
  "num-traits",
  "png",
-]
-
-[[package]]
-name = "imgui"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6a33933d4645d6db1bfa55ff75e13ef301644d4c001cfaec6fe3afcfb05b82c"
-dependencies = [
- "bitflags",
- "imgui-sys",
- "parking_lot",
-]
-
-[[package]]
-name = "imgui-sys"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "286f5338bd8281e3203de29cc317d123b178f2e565eca5aee770a2048074fdf7"
-dependencies = [
- "cc",
- "chlorine",
 ]
 
 [[package]]
@@ -1647,7 +1619,7 @@ dependencies = [
 [[package]]
 name = "smithay-egui"
 version = "0.1.0"
-source = "git+https://github.com/Smithay/smithay-egui#baa131d77b2fc2e3c2e87e881bba3ee18b315d14"
+source = "git+https://github.com/dragonnn/smithay-egui#1a8a03304eb8fdd5d770144de59f4ea9c0b94d56"
 dependencies = [
  "egui",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,10 @@ features = ["composite"]
 version = "0.9.0"
 features = ["executor", "futures-io"]
 
+[dependencies.smithay-egui]
+git = "https://github.com/Smithay/smithay-egui"
+commit = "baa131d77b2fc2e3c2e87e881bba3ee18b315d14"
+
 
 [features]
 default = ["udev", "winit", "x11"]
@@ -80,3 +84,6 @@ udev = [
 ]
 
 xwayland = ["smithay/xwayland", "smithay/x11rb_event_source", "x11rb"]
+
+[patch."https://github.com/Smithay/smithay.git"]
+smithay = { git = "https://github.com/PolyMeilex/smithay.git", branch = "seat-ddata" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ features = ["executor", "futures-io"]
 
 [dependencies.smithay-egui]
 git = "https://github.com/dragonnn/smithay-egui"
-commit = "1a8a03304eb8fdd5d770144de59f4ea9c0b94d56"
+rev = "1a8a03304eb8fdd5d770144de59f4ea9c0b94d56"
 
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,10 @@ lazy_static = "1.4.0"
 
 chrono = "0.4"
 
+egui_demo_lib = "0.16"
+
+derivative = "2.2.0"
+
 [dependencies.smithay]
 # git = "https://github.com/Smithay/smithay.git"
 git = "https://github.com/PolyMeilex/smithay.git"
@@ -62,6 +66,7 @@ features = ["executor", "futures-io"]
 [dependencies.smithay-egui]
 git = "https://github.com/Smithay/smithay-egui"
 commit = "baa131d77b2fc2e3c2e87e881bba3ee18b315d14"
+
 
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,6 @@ xkbcommon = "0.4.0"
 generational-arena = "0.2.8"
 cgmath = "0.18.0"
 
-imgui = "0.8.0"
-
 rhai = "1.3.0"
 
 futures = "0.3"
@@ -68,8 +66,8 @@ version = "0.9.0"
 features = ["executor", "futures-io"]
 
 [dependencies.smithay-egui]
-git = "https://github.com/Smithay/smithay-egui"
-commit = "baa131d77b2fc2e3c2e87e881bba3ee18b315d14"
+git = "https://github.com/dragonnn/smithay-egui"
+commit = "1a8a03304eb8fdd5d770144de59f4ea9c0b94d56"
 
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ generational-arena = "0.2.8"
 cgmath = "0.18.0"
 
 imgui = "0.8.0"
-imgui-smithay-renderer = { path = "./imgui-smithay-renderer" }
+
 rhai = "1.3.0"
 
 futures = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ lazy_static = "1.4.0"
 
 chrono = "0.4"
 
-egui_demo_lib = "0.16"
+egui = "0.16.1"
 
 derivative = "2.2.0"
 gumdrop = "0.8.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,8 +90,7 @@ udev = [
   "xcursor",
 ]
 
-xwayland = ["smithay/xwayland", "smithay/x11rb_event_source", "x11rb"]
+#xwayland = ["smithay/xwayland", "smithay/x11rb_event_source", "x11rb"]
 
 [patch."https://github.com/Smithay/smithay.git"]
 smithay = { git = "https://github.com/PolyMeilex/smithay.git", branch = "seat-ddata" }
-# xwayland = ["smithay/xwayland", "smithay/x11rb_event_source", "x11rb"]

--- a/config.rhai
+++ b/config.rhai
@@ -60,7 +60,7 @@ let weather = widget::text("");
 let date = widget::text("");
 let logger_box = box::new_raw(700, 330, 5, 35, layout::vertical());
 let logger = widget::logger();
-logger.c_debug = [1.0, 0.1, 1.0, 0.5];
+logger.c_debug = [255, 26, 255, 128];
 
 logger_box.background = false;
 logger_box.add_widget(logger.convert());
@@ -194,6 +194,7 @@ anodize.outputs.on_new(|output| {
     output.set_wallpaper("./resources/anocube.png");
 
     let top_box = box::new_raw(output.w, 15, 0, 0, layout::horizontal());
+    top_box.scroll = false;
     let fps_widget = widget::fps(output);
 
     top_box.add_widget(fps_widget.convert());

--- a/config.rhai
+++ b/config.rhai
@@ -11,7 +11,7 @@
 anodize.keyboard.callbacks.register(|| {
     anodize.log.info("starting weston terminal");
     anodize.system.exec("weston-terminal");
-    anodize.system.exec("xterm");
+    //anodize.system.exec("xterm");
 }, "Control_L", ["t"]);
 
 

--- a/src/config/outputs/shell/box.rs
+++ b/src/config/outputs/shell/box.rs
@@ -3,7 +3,6 @@ use std::rc::Rc;
 
 use calloop::channel::Sender;
 use egui::{Color32, CtxRef};
-use imgui::Ui;
 use rhai::Engine;
 use rhai::{plugin::*, FLOAT, INT};
 
@@ -19,15 +18,6 @@ thread_local! {
 pub enum Layout {
     Vertical,
     Horizontal,
-}
-
-impl Layout {
-    pub fn render(&self, ui: &Ui) {
-        match self {
-            Layout::Horizontal => ui.same_line(),
-            &Layout::Vertical => {}
-        }
-    }
 }
 
 //#[derive(Debug)]

--- a/src/config/outputs/shell/box.rs
+++ b/src/config/outputs/shell/box.rs
@@ -2,6 +2,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 use calloop::channel::Sender;
+use egui::{Color32, CtxRef};
 use imgui::Ui;
 use rhai::Engine;
 use rhai::{plugin::*, FLOAT, INT};
@@ -32,10 +33,10 @@ impl Layout {
 //#[derive(Debug)]
 pub struct BoxInner {
     id: String,
-    w: u16,
-    h: u16,
-    x: u32,
-    y: u32,
+    w: f32,
+    h: f32,
+    x: f32,
+    y: f32,
     layout: Layout,
     widgets: Vec<Rc<dyn Widget>>,
     alpha: f32,
@@ -50,7 +51,7 @@ pub struct Box {
 }
 
 impl Box {
-    pub fn new(w: u16, h: u16, x: u32, y: u32, layout: Layout) -> Self {
+    pub fn new(w: f32, h: f32, x: f32, y: f32, layout: Layout) -> Self {
         BOX_ID.with(move |id| {
             let mut id = id.borrow_mut();
             let r#box = Self {
@@ -74,24 +75,35 @@ impl Box {
         })
     }
 
-    pub fn render(&self, ui: &Ui, config_tx: &Sender<ConfigEvent>) {
+    pub fn render(&self, ctx: &CtxRef, config_tx: &Sender<ConfigEvent>) {
         let inner = self.inner.borrow();
         if inner.visable {
-            imgui::Window::new(&inner.id)
-                .size([inner.w as _, inner.h as _], imgui::Condition::Always)
-                .position([inner.x as _, inner.y as _], imgui::Condition::Always)
+            let mut frame = egui::Frame::window(&ctx.style());
+            if !inner.background {
+                frame.fill = Color32::TRANSPARENT;
+                frame.stroke.width = 0.0;
+            } else {
+                frame.fill[3] = (inner.alpha * 255.0) as u8;
+            }
+            egui::containers::Window::new(&inner.id)
+                .resize(|r| r.with_stroke(true)) //BUG : https://github.com/emilk/egui/issues/498, this work arounds it
+                .frame(frame)
+                .fixed_pos([inner.x, inner.y])
+                .fixed_size([inner.w, inner.h])
                 .title_bar(false)
-                .resizable(false)
-                .bg_alpha(inner.alpha)
-                .draw_background(inner.background)
-                .scroll_bar(inner.scroll)
-                .horizontal_scrollbar(inner.scroll)
-                .scrollable(inner.scroll)
-                .build(ui, || {
-                    for widget in &inner.widgets {
-                        widget.render(ui, config_tx);
-                        inner.layout.render(ui);
-                    }
+                .collapsible(false)
+                .scroll2([inner.scroll, inner.scroll])
+                .show(ctx, |ui| match inner.layout {
+                    Layout::Horizontal => ui.horizontal(|ui| {
+                        for widget in &inner.widgets {
+                            widget.render(ui, config_tx);
+                        }
+                    }),
+                    Layout::Vertical => ui.vertical(|ui| {
+                        for widget in &inner.widgets {
+                            widget.render(ui, config_tx);
+                        }
+                    }),
                 });
         }
     }

--- a/src/config/outputs/shell/button.rs
+++ b/src/config/outputs/shell/button.rs
@@ -1,7 +1,7 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
-use imgui::Ui;
+use egui::Ui;
 use rhai::plugin::*;
 use rhai::Engine;
 use rhai::FnPtr;
@@ -24,9 +24,10 @@ impl Button {
 }
 
 impl Widget for Button {
-    fn render(&self, ui: &Ui, config_tx: &Sender<ConfigEvent>) {
+    fn render(&self, ui: &mut Ui, config_tx: &Sender<ConfigEvent>) {
         let button = self.0.borrow();
-        if ui.button(&button.label) {
+        let response = ui.button(&button.label);
+        if response.clicked() {
             if let Some(click) = &button.click {
                 config_tx.send(ConfigEvent::Shell(click.clone())).unwrap();
             }

--- a/src/config/outputs/shell/fps.rs
+++ b/src/config/outputs/shell/fps.rs
@@ -1,6 +1,6 @@
 use std::rc::Rc;
 
-use imgui::Ui;
+use egui::Ui;
 use rhai::plugin::*;
 use rhai::Engine;
 
@@ -18,8 +18,8 @@ impl Fps {
 }
 
 impl Widget for Fps {
-    fn render(&self, ui: &Ui, _config_tx: &Sender<ConfigEvent>) {
-        ui.text(format!("FPS: {}", self.0.get_fps() as u32));
+    fn render(&self, ui: &mut Ui, _config_tx: &Sender<ConfigEvent>) {
+        ui.label(format!("FPS: {}", self.0.get_fps() as u32));
     }
 }
 

--- a/src/config/outputs/shell/logger/mod.rs
+++ b/src/config/outputs/shell/logger/mod.rs
@@ -4,7 +4,7 @@ mod filter;
 mod serializer;
 pub use drain::ShellDrain;
 
-use egui::Ui;
+use egui::{Color32, Ui};
 use rhai::plugin::*;
 use rhai::{Array, Engine};
 
@@ -18,12 +18,12 @@ use std::rc::Rc;
 
 #[derive(Debug, Clone)]
 pub struct LoggerInner {
-    trace: [f32; 4],
-    debug: [f32; 4],
-    info: [f32; 4],
-    warning: [f32; 4],
-    error: [f32; 4],
-    critical: [f32; 4],
+    trace: Color32,
+    debug: Color32,
+    info: Color32,
+    warning: Color32,
+    error: Color32,
+    critical: Color32,
 }
 
 #[derive(Debug, Clone)]
@@ -35,29 +35,34 @@ impl Logger {
     pub fn new() -> Self {
         Self {
             inner: Rc::new(RefCell::new(LoggerInner {
-                trace: [0.01, 0.93, 0.98, 1.0],
-                debug: [0.01, 0.93, 0.98, 1.0],
-                info: [0.41, 0.87, 0.67, 1.0],
-                warning: [0.95, 0.48, 0.43, 1.0],
-                error: [0.99, 0.27, 0.31, 1.0],
-                critical: [1.0, 0.49, 0.85, 1.0],
+                trace: Color32::from_rgb(3, 237, 250),
+                debug: Color32::from_rgb(3, 237, 250),
+                info: Color32::from_rgb(105, 222, 171),
+                warning: Color32::from_rgb(242, 122, 110),
+                error: Color32::from_rgb(252, 69, 79),
+                critical: Color32::from_rgb(255, 125, 217),
             })),
         }
     }
 
-    pub fn parse_color(new_color: Array) -> Option<[f32; 4]> {
-        if new_color.len() == 4 {
-            let mut parsed_color = [0.0, 0.0, 0.0, 0.0];
+    pub fn parse_color(new_color: Array) -> Option<Color32> {
+        if new_color.len() == 3 {
+            let mut parsed_color = [0, 0, 0, 255];
             for (i, new_color_part) in new_color.iter().enumerate() {
-                if let Ok(new_color_value) = new_color_part.as_float() {
-                    parsed_color[i] = new_color_value as f32;
+                if let Ok(new_color_value) = new_color_part.as_int() {
+                    parsed_color[i] = new_color_value as u8;
                 } else {
                     warn!("no float value in color, ignoring");
                     return None;
                 }
             }
 
-            Some(parsed_color)
+            Some(Color32::from_rgba_premultiplied(
+                parsed_color[0],
+                parsed_color[1],
+                parsed_color[2],
+                parsed_color[3],
+            ))
         } else {
             None
         }
@@ -68,19 +73,22 @@ impl Widget for Logger {
     fn render(&self, ui: &mut Ui, _config_tx: &Sender<ConfigEvent>) {
         let inner = self.inner.borrow();
         let buffer = BUFFER.lock().unwrap();
-        for (level, line) in buffer.iter() {
-            /*let token = match level {
-                Level::Trace => ui.push_style_color(StyleColor::Text, inner.trace),
-                Level::Debug => ui.push_style_color(StyleColor::Text, inner.debug),
-                Level::Info => ui.push_style_color(StyleColor::Text, inner.info),
-                Level::Warning => ui.push_style_color(StyleColor::Text, inner.warning),
-                Level::Error => ui.push_style_color(StyleColor::Text, inner.error),
-                Level::Critical => ui.push_style_color(StyleColor::Text, inner.critical),
-            };*/
-
-            ui.label(line);
-            //token.end();
-        }
+        egui::ScrollArea::vertical()
+            .auto_shrink([false, false])
+            .show(ui, |ui| {
+                for (level, line) in buffer.iter() {
+                    let mut label = egui::RichText::new(line);
+                    label = match level {
+                        Level::Trace => label.color(inner.trace),
+                        Level::Debug => label.color(inner.debug),
+                        Level::Info => label.color(inner.info),
+                        Level::Warning => label.color(inner.warning),
+                        Level::Error => label.color(inner.error),
+                        Level::Critical => label.color(inner.critical),
+                    };
+                    ui.add(egui::Label::new(label).wrap(true));
+                }
+            })
     }
 }
 

--- a/src/config/outputs/shell/logger/mod.rs
+++ b/src/config/outputs/shell/logger/mod.rs
@@ -4,7 +4,7 @@ mod filter;
 mod serializer;
 pub use drain::ShellDrain;
 
-use imgui::{StyleColor, Ui};
+use egui::Ui;
 use rhai::plugin::*;
 use rhai::{Array, Engine};
 
@@ -65,21 +65,21 @@ impl Logger {
 }
 
 impl Widget for Logger {
-    fn render(&self, ui: &Ui, _config_tx: &Sender<ConfigEvent>) {
+    fn render(&self, ui: &mut Ui, _config_tx: &Sender<ConfigEvent>) {
         let inner = self.inner.borrow();
         let buffer = BUFFER.lock().unwrap();
         for (level, line) in buffer.iter() {
-            let token = match level {
+            /*let token = match level {
                 Level::Trace => ui.push_style_color(StyleColor::Text, inner.trace),
                 Level::Debug => ui.push_style_color(StyleColor::Text, inner.debug),
                 Level::Info => ui.push_style_color(StyleColor::Text, inner.info),
                 Level::Warning => ui.push_style_color(StyleColor::Text, inner.warning),
                 Level::Error => ui.push_style_color(StyleColor::Text, inner.error),
                 Level::Critical => ui.push_style_color(StyleColor::Text, inner.critical),
-            };
+            };*/
 
-            ui.text_wrapped(line);
-            token.end();
+            ui.label(line);
+            //token.end();
         }
     }
 }

--- a/src/config/outputs/shell/logger/serializer.rs
+++ b/src/config/outputs/shell/logger/serializer.rs
@@ -30,9 +30,7 @@ impl ShellSerializer {
     }
 
     pub fn end(self) -> Result<String, slog::Error> {
-        let mut data = self.data;
-        data.write_char('\n')?;
-        Ok(data)
+        Ok(self.data)
     }
 }
 

--- a/src/config/outputs/shell/mod.rs
+++ b/src/config/outputs/shell/mod.rs
@@ -1,7 +1,7 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
-use imgui::Ui;
+use egui::CtxRef;
 use rhai::plugin::*;
 use rhai::Engine;
 
@@ -32,9 +32,9 @@ impl Shell {
         self.boxes.borrow_mut().push(r#box);
     }
 
-    pub fn render(&self, ui: &Ui, config_tx: &Sender<ConfigEvent>) {
+    pub fn render(&self, ctx: &CtxRef, config_tx: &Sender<ConfigEvent>) {
         for r#box in self.boxes.borrow().iter() {
-            r#box.render(ui, config_tx);
+            r#box.render(ctx, config_tx);
         }
     }
 }

--- a/src/config/outputs/shell/output.rs
+++ b/src/config/outputs/shell/output.rs
@@ -1,6 +1,6 @@
 use std::rc::Rc;
 
-use imgui::Ui;
+use egui::Ui;
 use rhai::plugin::*;
 use rhai::Engine;
 
@@ -18,8 +18,8 @@ impl OutputGeometry {
 }
 
 impl Widget for OutputGeometry {
-    fn render(&self, ui: &Ui, _config_tx: &Sender<ConfigEvent>) {
-        ui.text(format!("Geometry: {:?}", self.0.geometry()));
+    fn render(&self, ui: &mut Ui, _config_tx: &Sender<ConfigEvent>) {
+        ui.label(format!("Geometry: {:?}", self.0.geometry()));
     }
 }
 

--- a/src/config/outputs/shell/text.rs
+++ b/src/config/outputs/shell/text.rs
@@ -1,7 +1,7 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
-use imgui::Ui;
+use egui::Ui;
 use rhai::plugin::*;
 use rhai::Engine;
 
@@ -17,8 +17,8 @@ impl Text {
 }
 
 impl Widget for Text {
-    fn render(&self, ui: &Ui, _config_tx: &Sender<ConfigEvent>) {
-        ui.text(&*self.0.borrow());
+    fn render(&self, ui: &mut Ui, _config_tx: &Sender<ConfigEvent>) {
+        ui.label(&*self.0.borrow());
     }
 }
 

--- a/src/config/outputs/shell/widget.rs
+++ b/src/config/outputs/shell/widget.rs
@@ -1,11 +1,11 @@
 pub use calloop::channel::Sender;
-use imgui::Ui;
+use egui::Ui;
 use rhai::plugin::*;
 
 pub use crate::config::eventloop::ConfigEvent;
 
 pub trait Widget {
-    fn render(&self, ui: &Ui, config_tx: &Sender<ConfigEvent>);
+    fn render(&self, ui: &mut Ui, config_tx: &Sender<ConfigEvent>);
 }
 
 impl std::fmt::Debug for Box<dyn Widget> {

--- a/src/config/outputs/shell/workspace.rs
+++ b/src/config/outputs/shell/workspace.rs
@@ -1,6 +1,6 @@
 use std::rc::Rc;
 
-use imgui::Ui;
+use egui::Ui;
 use rhai::plugin::*;
 use rhai::Engine;
 
@@ -18,8 +18,8 @@ impl CurrentWorkspace {
 }
 
 impl Widget for CurrentWorkspace {
-    fn render(&self, ui: &Ui, _config_tx: &Sender<ConfigEvent>) {
-        ui.text(format!("Workspace: {}", self.0.active_workspace()));
+    fn render(&self, ui: &mut Ui, _config_tx: &Sender<ConfigEvent>) {
+        ui.label(format!("Workspace: {}", self.0.active_workspace()));
     }
 }
 

--- a/src/framework/backend/udev.rs
+++ b/src/framework/backend/udev.rs
@@ -384,20 +384,6 @@ fn scan_connectors<D: 'static>(
                         })
                         .collect();
 
-                    let mut imgui = imgui::Context::create();
-                    {
-                        imgui.set_ini_filename(None);
-                        let io = imgui.io_mut();
-                        io.display_framebuffer_scale = [1.0f32, 1.0f32];
-                        io.display_size = [size.0 as f32, size.1 as f32];
-                    }
-
-                    let imgui_pipeline = renderer
-                        .with_context(|_, gles| {
-                            imgui_smithay_renderer::Renderer::new(gles, &mut imgui)
-                        })
-                        .unwrap();
-
                     let output = Output::new(
                         &output_name,
                         Default::default(),
@@ -410,8 +396,6 @@ fn scan_connectors<D: 'static>(
                         },
                         output_mode,
                         output_modes,
-                        imgui,
-                        imgui_pipeline,
                         // TODO: output should always have a workspace
                         "Unknown".into(),
                         slog_scope::logger(),

--- a/src/framework/backend/winit.rs
+++ b/src/framework/backend/winit.rs
@@ -94,21 +94,6 @@ where
         refresh: 60_000,
     };
 
-    info!("imgui!");
-    let mut imgui = imgui::Context::create();
-    {
-        imgui.set_ini_filename(None);
-        let io = imgui.io_mut();
-        io.display_framebuffer_scale = [1.0f32, 1.0f32];
-        io.display_size = [size.w as f32, size.h as f32];
-    }
-
-    let imgui_pipeline = backend
-        .borrow_mut()
-        .renderer()
-        .with_context(|_, gles| imgui_smithay_renderer::Renderer::new(gles, &mut imgui))
-        .unwrap();
-
     let mut output = Output::new(
         OUTPUT_NAME,
         Default::default(),
@@ -121,8 +106,6 @@ where
         },
         mode,
         vec![mode],
-        imgui,
-        imgui_pipeline,
         // TODO: output should always have a workspace
         "Unknown".into(),
         slog_scope::logger(),

--- a/src/framework/backend/x11.rs
+++ b/src/framework/backend/x11.rs
@@ -76,7 +76,7 @@ impl OutputSurfaceBuilder {
         Self { surface, window }
     }
 
-    fn build(self, display: &mut Display, renderer: &mut Gles2Renderer) -> OutputSurface {
+    fn build(self, display: &mut Display) -> OutputSurface {
         let size = {
             let s = self.window.size();
             (s.w as i32, s.h as i32).into()
@@ -227,7 +227,7 @@ where
 
     let surface_datas: Vec<_> = x11_outputs
         .into_iter()
-        .map(|o| o.build(&mut display.borrow_mut(), &mut renderer.borrow_mut()))
+        .map(|o| o.build(&mut display.borrow_mut()))
         .collect();
 
     for surface_data in surface_datas.iter() {

--- a/src/framework/backend/x11.rs
+++ b/src/framework/backend/x11.rs
@@ -87,18 +87,6 @@ impl OutputSurfaceBuilder {
             refresh: 60_000,
         };
 
-        let mut imgui = imgui::Context::create();
-        {
-            imgui.set_ini_filename(None);
-            let io = imgui.io_mut();
-            io.display_framebuffer_scale = [1.0f32, 1.0f32];
-            io.display_size = [size.w as f32, size.h as f32];
-        }
-
-        let imgui_pipeline = renderer
-            .with_context(|_, gles| imgui_smithay_renderer::Renderer::new(gles, &mut imgui))
-            .unwrap();
-
         let output = Output::new(
             OUTPUT_NAME,
             Default::default(),
@@ -111,8 +99,6 @@ impl OutputSurfaceBuilder {
             },
             mode,
             vec![mode],
-            imgui,
-            imgui_pipeline,
             // TODO: output should always have a workspace
             "Unknown".into(),
             slog_scope::logger(),

--- a/src/input_handler.rs
+++ b/src/input_handler.rs
@@ -84,13 +84,13 @@ impl Anodium {
     }
 
     fn reset_imgui_event(&self, output: &Output) {
-        let (mut imgui, pipeline) = output.take_imgui();
+        /*let (mut imgui, pipeline) = output.take_imgui();
         imgui.io_mut().mouse_pos = [f32::MAX, f32::MAX];
-        output.restore_imgui((imgui, pipeline));
+        output.restore_imgui((imgui, pipeline));*/
     }
 
     fn process_imgui_event<I: InputBackend>(&self, event: InputEvent<I>, output: &Output) {
-        let mouse_location = self.input_state.pointer_location - output.location().to_f64();
+        /*let mouse_location = self.input_state.pointer_location - output.location().to_f64();
         let (mut imgui, pipeline) = output.take_imgui();
         let mut io = imgui.io_mut();
 
@@ -134,7 +134,7 @@ impl Anodium {
             _ => {}
         }
 
-        output.restore_imgui((imgui, pipeline));
+        output.restore_imgui((imgui, pipeline));*/
     }
 
     fn keyboard_key_to_action<I: InputBackend>(&mut self, evt: &I::KeyboardKeyEvent) -> KeyAction {

--- a/src/input_handler.rs
+++ b/src/input_handler.rs
@@ -76,20 +76,21 @@ impl Anodium {
             .find_by_position(self.input_state.pointer_location.to_i32_round())
         {
             if captured {
-                self.process_imgui_event(event, &output);
+                self.process_egui_event(event, &output);
             } else {
-                self.reset_imgui_event(&output);
+                self.reset_egui_event(&output);
             }
         }
     }
 
-    fn reset_imgui_event(&self, output: &Output) {
-        /*let (mut imgui, pipeline) = output.take_imgui();
-        imgui.io_mut().mouse_pos = [f32::MAX, f32::MAX];
-        output.restore_imgui((imgui, pipeline));*/
+    fn reset_egui_event(&self, output: &Output) {
+        let mut max_point = Point::default();
+        max_point.x = i32::MAX;
+        max_point.y = i32::MAX;
+        output.egui().handle_pointer_motion(max_point);
     }
 
-    fn process_imgui_event<I: InputBackend>(&self, event: InputEvent<I>, output: &Output) {
+    fn process_egui_event<I: InputBackend>(&self, event: InputEvent<I>, output: &Output) {
         match event {
             InputEvent::PointerMotion { .. } | InputEvent::PointerMotionAbsolute { .. } => {
                 let mouse_location = self.input_state.pointer_location - output.location().to_f64();

--- a/src/input_handler.rs
+++ b/src/input_handler.rs
@@ -6,8 +6,8 @@ use crate::{
 
 use smithay::{
     backend::input::{
-        self, Event, InputBackend, InputEvent, KeyState, KeyboardKeyEvent, PointerAxisEvent,
-        PointerButtonEvent, PointerMotionAbsoluteEvent, PointerMotionEvent,
+        self, ButtonState, Event, InputBackend, InputEvent, KeyState, KeyboardKeyEvent,
+        PointerAxisEvent, PointerButtonEvent, PointerMotionAbsoluteEvent, PointerMotionEvent,
     },
     reexports::wayland_server::protocol::wl_pointer,
     utils::{Logical, Point},
@@ -90,51 +90,47 @@ impl Anodium {
     }
 
     fn process_imgui_event<I: InputBackend>(&self, event: InputEvent<I>, output: &Output) {
-        /*let mouse_location = self.input_state.pointer_location - output.location().to_f64();
-        let (mut imgui, pipeline) = output.take_imgui();
-        let mut io = imgui.io_mut();
-
-        io.mouse_pos[0] = mouse_location.x as f32;
-        io.mouse_pos[1] = mouse_location.y as f32;
-
         match event {
-            InputEvent::Keyboard { event, .. } => {
-                let keycode = event.key_code();
-                let state = event.state();
-                match state {
-                    KeyState::Pressed => io.keys_down[keycode as usize] = true,
-                    KeyState::Released => io.keys_down[keycode as usize] = false,
-                }
+            InputEvent::PointerMotion { .. } | InputEvent::PointerMotionAbsolute { .. } => {
+                let mouse_location = self.input_state.pointer_location - output.location().to_f64();
+                output
+                    .egui()
+                    .handle_pointer_motion(mouse_location.to_i32_round());
             }
 
             InputEvent::PointerButton { event, .. } => {
-                let button = event.button().unwrap();
-                let state = event.state() == input::ButtonState::Pressed;
-
-                match button {
-                    input::MouseButton::Left => io.mouse_down[0] = state,
-                    input::MouseButton::Right => io.mouse_down[1] = state,
-                    input::MouseButton::Middle => io.mouse_down[2] = state,
-                    _ => {}
-                };
-            }
-
-            InputEvent::PointerAxis { event, .. } => {
-                if event.source() == input::AxisSource::Wheel {
-                    let amount_discrete =
-                        event.amount_discrete(input::Axis::Vertical).unwrap() * 0.3;
-                    // TODO - find a better way to handle this, why does it scrool on wayland in opposite direction?!
-                    if self.seat_name == "x11" || self.seat_name == "winit" {
-                        io.mouse_wheel += amount_discrete as f32;
-                    } else {
-                        io.mouse_wheel -= amount_discrete as f32;
-                    }
+                if let Some(button) = event.button() {
+                    output.egui().handle_pointer_button(
+                        button,
+                        event.state() == ButtonState::Pressed,
+                        self.input_state.modifiers_state.clone(),
+                    );
                 }
             }
+
+            InputEvent::Keyboard { event } => {
+                //TODO - is that enough or do we need the whole code from here https://github.com/Smithay/smithay-egui/blob/main/examples/integrate.rs#L69 ?
+                output.egui().handle_keyboard(
+                    &[event.key_code()],
+                    event.state() == KeyState::Pressed,
+                    self.input_state.modifiers_state.clone(),
+                );
+            }
+
+            InputEvent::PointerAxis { event, .. } => output.egui().handle_pointer_axis(
+                event
+                    .amount_discrete(input::Axis::Horizontal)
+                    .or_else(|| event.amount(input::Axis::Horizontal).map(|x| x * 3.0))
+                    .unwrap_or(0.0)
+                    * 10.0,
+                event
+                    .amount_discrete(input::Axis::Vertical)
+                    .or_else(|| event.amount(input::Axis::Vertical).map(|x| x * 3.0))
+                    .unwrap_or(0.0)
+                    * 10.0,
+            ),
             _ => {}
         }
-
-        output.restore_imgui((imgui, pipeline));*/
     }
 
     fn keyboard_key_to_action<I: InputBackend>(&mut self, evt: &I::KeyboardKeyEvent) -> KeyAction {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,5 @@
 #![allow(clippy::too_many_arguments)]
 #![allow(irrefutable_let_patterns)]
-#![feature(cell_leak)]
 
 #[macro_use]
 extern crate slog_scope;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::too_many_arguments)]
 #![allow(irrefutable_let_patterns)]
+#![feature(cell_leak)]
 
 #[macro_use]
 extern crate slog_scope;

--- a/src/output_map/output.rs
+++ b/src/output_map/output.rs
@@ -132,8 +132,10 @@ impl Output {
         N: AsRef<str>,
     {
         let egui = EguiState::new();
-        let mut visuals = egui::style::Visuals::default();
-        visuals.window_corner_radius = 0.0;
+        let visuals = egui::style::Visuals {
+            window_corner_radius: 0.0,
+            ..Default::default()
+        };
 
         egui.context().set_visuals(visuals);
 

--- a/src/output_map/output.rs
+++ b/src/output_map/output.rs
@@ -4,7 +4,6 @@ use std::time::Instant;
 
 use calloop::channel::Sender;
 
-use imgui::{Context, SuspendedContext, Ui};
 use smithay_egui::{EguiFrame, EguiState};
 
 use smithay::backend::renderer::gles2::{Gles2Renderer, Gles2Texture};
@@ -327,6 +326,10 @@ impl Output {
 
     pub fn update_fps(&self, fps: f64) {
         self.inner.borrow_mut().fps = fps;
+    }
+
+    pub fn egui(&self) -> RefMut<EguiState> {
+        RefMut::map(self.inner.borrow_mut(), |o| o.egui.as_mut().unwrap())
     }
 }
 

--- a/src/output_map/output.rs
+++ b/src/output_map/output.rs
@@ -49,7 +49,7 @@ struct Inner {
 
     imgui: Option<(SuspendedContext, Renderer)>,
     #[derivative(Debug = "ignore")]
-    egui: Option<(EguiState, egui_demo_lib::DemoWindows, ModifiersState)>,
+    egui: Option<EguiState>,
     shell: Shell,
 
     fps: f64,
@@ -152,8 +152,10 @@ impl Output {
         N: AsRef<str>,
     {
         let egui = EguiState::new();
-        let demo_ui = egui_demo_lib::DemoWindows::default();
-        let egui_modifiers = ModifiersState::default();
+        let mut visuals = egui::style::Visuals::default();
+        visuals.window_corner_radius = 0.0;
+
+        egui.context().set_visuals(visuals);
 
         let (output, global) = output::Output::new(display, name.as_ref().into(), physical, logger);
 
@@ -181,7 +183,7 @@ impl Output {
                 wallpaper_texture: None,
 
                 imgui: Some((imgui_context.suspend(), imgui_pipeline)),
-                egui: Some((egui, demo_ui, egui_modifiers)),
+                egui: Some(egui),
                 shell: Shell::new(),
                 fps: 0.0,
             })),
@@ -326,11 +328,11 @@ impl Output {
         self.inner.borrow_mut().imgui = Some((context.suspend(), pipeline));
     }
 
-    pub fn get_egui(&self) -> (EguiState, egui_demo_lib::DemoWindows, ModifiersState) {
+    pub fn get_egui(&self) -> EguiState {
         self.inner.borrow_mut().egui.take().unwrap()
     }
 
-    pub fn restore_egui(&self, egui: (EguiState, egui_demo_lib::DemoWindows, ModifiersState)) {
+    pub fn restore_egui(&self, egui: EguiState) {
         self.inner.borrow_mut().egui = Some(egui);
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -392,10 +392,20 @@ impl Anodium {
 
         {
             let size = output.size().to_physical(1);
-            let (mut egui, mut demo, modifires) = output.get_egui();
-
-            let egui_frame = egui.run(
-                |ctx| demo.ui(ctx),
+            let mut egui_holder = output.get_egui();
+            let egui_frame = egui_holder.run(
+                |ctx| {
+                    egui::containers::Window::new("test")
+                        .resize(|r| r.with_stroke(true)) //BUG : https://github.com/emilk/egui/issues/498, this work arounds it
+                        .fixed_pos([0.0, 0.0])
+                        .fixed_size([100.0, 100.0])
+                        .title_bar(false)
+                        .collapsible(false)
+                        .show(ctx, |ui| {
+                            ui.label("wtf");
+                            ui.label("wtf");
+                        });
+                },
                 // Just render it over the whole window, but you may limit the area
                 Rectangle::from_loc_and_size((0, 0), size.to_logical(1)),
                 size,
@@ -403,14 +413,14 @@ impl Anodium {
                 1.0,
                 1.0,
                 &self.start_time,
-                modifires.clone(),
+                self.input_state.modifiers_state.clone(),
             );
 
             unsafe {
                 egui_frame.draw(frame.renderer, frame.frame).unwrap();
             }
 
-            output.restore_egui((egui, demo, modifires));
+            output.restore_egui(egui_holder);
         }
 
         self.draw_layers(frame, Layer::Bottom, output_geometry, output_scale)?;

--- a/src/state.rs
+++ b/src/state.rs
@@ -372,25 +372,6 @@ impl Anodium {
         }
 
         {
-            let (mut context, pipeline) = output.take_imgui();
-            let ui = context.frame();
-
-            output.render_shell(&ui, &self.config_tx);
-
-            let draw_data = ui.render();
-            let transform = frame.transform;
-
-            frame
-                .renderer
-                .with_context(|_renderer, gles| {
-                    pipeline.render(transform, gles, draw_data);
-                })
-                .unwrap();
-
-            output.restore_imgui((context, pipeline));
-        }
-
-        {
             let size = output.size().to_physical(1);
             let mut egui_holder = output.get_egui();
             let egui_frame = egui_holder.run(

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,5 +1,5 @@
 use std::{
-    cell::{Ref, RefCell, RefMut},
+    cell::RefCell,
     collections::{HashMap, HashSet},
     rc::Rc,
     sync::{

--- a/src/state.rs
+++ b/src/state.rs
@@ -372,36 +372,15 @@ impl Anodium {
         }
 
         {
-            let size = output.size().to_physical(1);
-            let mut egui_holder = output.get_egui();
-            let egui_frame = egui_holder.run(
-                |ctx| {
-                    egui::containers::Window::new("test")
-                        .resize(|r| r.with_stroke(true)) //BUG : https://github.com/emilk/egui/issues/498, this work arounds it
-                        .fixed_pos([0.0, 0.0])
-                        .fixed_size([100.0, 100.0])
-                        .title_bar(false)
-                        .collapsible(false)
-                        .show(ctx, |ui| {
-                            ui.label("wtf");
-                            ui.label("wtf");
-                        });
-                },
-                // Just render it over the whole window, but you may limit the area
-                Rectangle::from_loc_and_size((0, 0), size.to_logical(1)),
-                size,
-                // we also completely ignore the scale *everywhere* in this example, but egui is HiDPI-ready
-                1.0,
-                1.0,
+            let egui_frame = output.render_shell(
                 &self.start_time,
-                self.input_state.modifiers_state.clone(),
+                &self.input_state.modifiers_state,
+                &self.config_tx,
             );
 
             unsafe {
                 egui_frame.draw(frame.renderer, frame.frame).unwrap();
             }
-
-            output.restore_egui(egui_holder);
         }
 
         self.draw_layers(frame, Layer::Bottom, output_geometry, output_scale)?;

--- a/src/state.rs
+++ b/src/state.rs
@@ -381,6 +381,11 @@ impl Anodium {
             unsafe {
                 egui_frame.draw(frame.renderer, frame.frame).unwrap();
             }
+            //TODO - this a bad workaround around egui_frame.draw breaking the next rendered texture, but it works for now
+            frame.clear(
+                [0.1, 0.1, 0.1, 1.0],
+                &[Rectangle::from_loc_and_size((0, 0), (0, 0))],
+            )?;
         }
 
         self.draw_layers(frame, Layer::Bottom, output_geometry, output_scale)?;

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,5 +1,5 @@
 use std::{
-    cell::RefCell,
+    cell::{Ref, RefCell, RefMut},
     collections::{HashMap, HashSet},
     rc::Rc,
     sync::{
@@ -376,6 +376,29 @@ impl Anodium {
                 .unwrap();
 
             output.restore_imgui((context, pipeline));
+        }
+
+        {
+            let size = output.size().to_physical(1);
+            let (mut egui, mut demo, modifires) = output.get_egui();
+
+            let egui_frame = egui.run(
+                |ctx| demo.ui(ctx),
+                // Just render it over the whole window, but you may limit the area
+                Rectangle::from_loc_and_size((0, 0), size.to_logical(1)),
+                size,
+                // we also completely ignore the scale *everywhere* in this example, but egui is HiDPI-ready
+                1.0,
+                1.0,
+                &self.start_time,
+                modifires.clone(),
+            );
+
+            unsafe {
+                egui_frame.draw(frame.renderer, frame.frame).unwrap();
+            }
+
+            output.restore_egui((egui, demo, modifires));
         }
 
         self.draw_layers(frame, Layer::Bottom, output_geometry, output_scale)?;


### PR DESCRIPTION
This PR replaces imgui with egui. All shell elements have bean already rewritten to use egui.
Only one know issue is left: the first texture after egui is draw is not displayed on the screen, if we add for example a dummy draw of a texture with 0,0 size it starts working so I suspect a gl command missing in smithay-egui draw function?