### PR TITLE
Implement FPS widget back, update smithay-egui

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1559,7 +1559,7 @@ dependencies = [
 [[package]]
 name = "smithay"
 version = "0.3.0"
-source = "git+https://github.com/PolyMeilex/smithay.git?branch=seat-ddata#574adcb79f02b6336aebd46a189128ac82615342"
+source = "git+https://github.com/PolyMeilex/smithay.git?branch=seat-ddata#6d530ef252467ca168fdd9d201319a8e1db1aca6"
 dependencies = [
  "appendlist",
  "bitflags",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1619,7 +1619,7 @@ dependencies = [
 [[package]]
 name = "smithay-egui"
 version = "0.1.0"
-source = "git+https://github.com/dragonnn/smithay-egui?rev=1a8a03304eb8fdd5d770144de59f4ea9c0b94d56#1a8a03304eb8fdd5d770144de59f4ea9c0b94d56"
+source = "git+https://github.com/dragonnn/smithay-egui?rev=c2a931caed542eb82a7056dec506a40819c40e61#c2a931caed542eb82a7056dec506a40819c40e61"
 dependencies = [
  "egui",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,12 +67,12 @@ features = ["executor", "futures-io"]
 
 [dependencies.smithay-egui]
 git = "https://github.com/dragonnn/smithay-egui"
-rev = "1a8a03304eb8fdd5d770144de59f4ea9c0b94d56"
+rev = "c2a931caed542eb82a7056dec506a40819c40e61"
 
 
 
 [features]
-default = ["udev", "winit", "x11"]
+default = ["udev", "winit", "x11", "debug"]
 # default = ["udev","winit", "xwayland"]
 #default = ["udev","winit"]
 x11 = ["smithay/backend_x11", "x11rb"]
@@ -89,7 +89,7 @@ udev = [
   "image",
   "xcursor",
 ]
-
+debug = []
 #xwayland = ["smithay/xwayland", "smithay/x11rb_event_source", "x11rb"]
 
 [patch."https://github.com/Smithay/smithay.git"]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -68,7 +68,7 @@ impl ConfigVM {
 
         let ast = engine.compile_file(config)?;
 
-        engine.eval_ast_with_scope(&mut scope, &ast)?;
+        let _ignore: Dynamic = engine.eval_ast_with_scope(&mut scope, &ast)?;
 
         Ok(ConfigVM {
             inner: Rc::new(RefCell::new(Inner { engine, ast, scope })),

--- a/src/config/outputs/shell/fps.rs
+++ b/src/config/outputs/shell/fps.rs
@@ -1,4 +1,6 @@
+use std::cell::RefCell;
 use std::rc::Rc;
+use std::time::Instant;
 
 use egui::Ui;
 use rhai::plugin::*;
@@ -9,18 +11,46 @@ use crate::output_manager::Output;
 use super::widget::*;
 
 #[derive(Debug, Clone)]
-pub struct Fps(Output);
+struct Inner {
+    old_fps: u32,
+    old_fps_timeout: Instant,
+}
+
+#[derive(Debug, Clone)]
+pub struct Fps {
+    output: Output,
+    inner: Rc<RefCell<Inner>>,
+}
 
 impl Fps {
     pub fn new(output: Output) -> Self {
-        Self(output)
+        let current_fps = output.get_fps();
+        Self {
+            output,
+            inner: Rc::new(RefCell::new(Inner {
+                old_fps: current_fps,
+                old_fps_timeout: Instant::now(),
+            })),
+        }
     }
 }
 
 impl Widget for Fps {
+    #[cfg(feature = "debug")]
     fn render(&self, ui: &mut Ui, _config_tx: &Sender<ConfigEvent>) {
-        // ui.text(format!("FPS: {}", self.0.get_fps() as u32));
-        ui.label(format!("FPS: {}", 0));
+        let mut inner = self.inner.borrow_mut();
+        if inner.old_fps_timeout.elapsed().as_secs() >= 1 {
+            inner.old_fps = self.output.get_fps();
+            ui.ctx().request_repaint();
+            inner.old_fps_timeout = Instant::now();
+        }
+        ui.label(format!("FPS: {}", inner.old_fps as u32));
+        //ui.label(format!("FPS: {}", 0));
+    }
+
+    #[cfg(not(feature = "debug"))]
+    fn render(&self, ui: &mut Ui, _config_tx: &Sender<ConfigEvent>) {
+        ui.label("FPS: debug feature not enabled");
     }
 }
 

--- a/src/framework/backend/udev.rs
+++ b/src/framework/backend/udev.rs
@@ -265,7 +265,6 @@ struct OutputSurfaceData {
 
     surface: RenderSurface,
     _render_timer: RenderTimerHandle,
-    fps: fps_ticker::Fps,
     _connector_info: connector::Info,
     crtc: crtc::Handle,
 }
@@ -419,7 +418,6 @@ where
 
                         surface: gbm_surface,
                         _render_timer: timer.handle(),
-                        fps: fps_ticker::Fps::default(),
                         _connector_info: connector_info,
                         crtc,
                     })));
@@ -796,8 +794,6 @@ where
 
     // and draw to our buffer
     handler.output_render(renderer, output, Some(pointer_image));
-
-    surface.fps.tick();
 
     surface
         .surface

--- a/src/framework/backend/winit.rs
+++ b/src/framework/backend/winit.rs
@@ -114,8 +114,6 @@ where
     let timer = Timer::new().unwrap();
     let timer_handle = timer.handle();
 
-    let fps = fps_ticker::Fps::default();
-
     event_loop
         .handle()
         .insert_source(timer, move |_: (), timer_handle, handler| {
@@ -145,8 +143,6 @@ where
                     }
 
                     handler.send_frames();
-
-                    fps.tick();
 
                     timer_handle.add_timeout(Duration::from_millis(16), ());
                 }

--- a/src/framework/backend/x11.rs
+++ b/src/framework/backend/x11.rs
@@ -34,8 +34,6 @@ struct OutputSurface {
     surface: X11Surface,
     window: smithay::backend::x11::Window,
 
-    fps: fps_ticker::Fps,
-
     _output_name: String,
     output: Output,
     mode: Mode,
@@ -111,8 +109,6 @@ impl OutputSurfaceBuilder {
         OutputSurface {
             surface: self.surface,
             window: self.window,
-
-            fps: fps_ticker::Fps::default(),
             mode,
             _output_name: "X11(1)".into(),
             output,
@@ -271,8 +267,6 @@ where
                             // }
                         }
                     }
-
-                    surface_data.fps.tick();
                 }
 
                 handler.send_frames();

--- a/src/output_manager/output.rs
+++ b/src/output_manager/output.rs
@@ -47,6 +47,9 @@ struct Data {
 
     egui: RefCell<EguiState>,
     egui_shell: Shell,
+
+    #[cfg(feature = "debug")]
+    fps_ticker: fps_ticker::Fps,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -101,6 +104,7 @@ impl Output {
             possible_modes: RefCell::new(possible_modes),
             egui: RefCell::new(egui),
             egui_shell: Shell::new(),
+            fps_ticker: fps_ticker::Fps::default(),
         });
         assert!(added);
 
@@ -158,6 +162,16 @@ impl Output {
             start_time,
             *modifiers,
         )
+    }
+
+    #[cfg(feature = "debug")]
+    pub fn tick_fps(&self) {
+        self.data().fps_ticker.tick();
+    }
+
+    #[cfg(feature = "debug")]
+    pub fn get_fps(&self) -> u32 {
+        self.data().fps_ticker.avg().round() as u32
     }
 }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -385,10 +385,25 @@ impl Anodium {
             // TODO:
             let _todo = pointer_image;
         }
-
-        self.workspace
-            .render_output(renderer, output, 0, [0.1, 0.1, 0.1, 1.0], &elems)
+        let render_result = self
+            .workspace
+            .render_output(
+                renderer,
+                output,
+                0,
+                [0.1, 0.1, 0.1, 1.0],
+                &bottom_elems,
+                &top_elems,
+            )
             .unwrap();
+
+        if let Some(render_result) = render_result {
+            if !render_result.is_empty() {
+                #[cfg(feature = "debug")]
+                output.tick_fps();
+                return Err(smithay::backend::SwapBuffersError::AlreadySwapped);
+            }
+        }
 
         Ok(())
     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -394,7 +394,6 @@ impl Anodium {
             if !render_result.is_empty() {
                 #[cfg(feature = "debug")]
                 output.tick_fps();
-                return Err(smithay::backend::SwapBuffersError::AlreadySwapped);
             }
         }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -387,14 +387,7 @@ impl Anodium {
         }
         let render_result = self
             .workspace
-            .render_output(
-                renderer,
-                output,
-                0,
-                [0.1, 0.1, 0.1, 1.0],
-                &bottom_elems,
-                &top_elems,
-            )
+            .render_output(renderer, output, 0, [0.1, 0.1, 0.1, 1.0], &elems)
             .unwrap();
 
         if let Some(render_result) = render_result {


### PR DESCRIPTION
This PR implements back FPS widget, in this implementation the widget only updates once in one 1s.
This is done to avoid the widget it self triggering too much redraws itself and this to spin up to max FPS.
PR also updates smithay-egui which includes a simple damage tracking (still work in progress but works already).