### PR TITLE
Add damage tracking to PointerElement, smal egui fixes

### DIFF
--- a/src/framework/cursor.rs
+++ b/src/framework/cursor.rs
@@ -117,15 +117,21 @@ pub struct PointerElement {
     texture: Gles2Texture,
     position: Point<i32, Logical>,
     size: Size<i32, Logical>,
+    damaged: bool,
 }
 
 impl PointerElement {
-    pub fn new(texture: Gles2Texture, relative_pointer_pos: Point<i32, Logical>) -> PointerElement {
+    pub fn new(
+        texture: Gles2Texture,
+        relative_pointer_pos: Point<i32, Logical>,
+        damaged: bool,
+    ) -> PointerElement {
         let size = texture.size().to_logical(1, Transform::Normal);
         PointerElement {
             texture,
             position: relative_pointer_pos,
             size,
+            damaged,
         }
     }
 }
@@ -143,7 +149,11 @@ impl RenderElement<Gles2Renderer, Gles2Frame, Gles2Error, Gles2Texture> for Poin
         &self,
         _: Option<SpaceOutputTuple<'_, '_>>,
     ) -> Vec<Rectangle<i32, Logical>> {
-        vec![Rectangle::from_loc_and_size((0, 0), self.size)]
+        if self.damaged {
+            vec![Rectangle::from_loc_and_size((0, 0), self.size)]
+        } else {
+            vec![]
+        }
     }
 
     fn draw(

--- a/src/output_manager/output.rs
+++ b/src/output_manager/output.rs
@@ -160,6 +160,7 @@ impl Output {
         let data = self.data();
         data.egui.borrow_mut().run(
             |ctx| {
+                //TODO - fix that in smithay, currently if crashes if egui does not have any element
                 egui::Area::new("main")
                     .anchor(egui::Align2::LEFT_TOP, (10.0, 10.0))
                     .show(ctx, |_ui| {});

--- a/src/output_manager/output.rs
+++ b/src/output_manager/output.rs
@@ -103,6 +103,7 @@ impl Output {
         visuals.widgets.hovered.corner_radius = 0.0;
         visuals.widgets.active.corner_radius = 0.0;
         visuals.widgets.open.corner_radius = 0.0;
+        visuals.window_shadow.extrusion = 0.0;
 
         egui.context().set_visuals(visuals);
 
@@ -158,10 +159,6 @@ impl Output {
         let data = self.data();
         data.egui.borrow_mut().run(
             |ctx| {
-                egui::Area::new("main")
-                    .anchor(egui::Align2::LEFT_TOP, (10.0, 10.0))
-                    .show(ctx, |_ui| {});
-
                 data.egui_shell.render(ctx, config_tx);
             },
             Rectangle::from_loc_and_size((0, 0), size.to_logical(scale)),

--- a/src/output_manager/output.rs
+++ b/src/output_manager/output.rs
@@ -160,6 +160,9 @@ impl Output {
         let data = self.data();
         data.egui.borrow_mut().run(
             |ctx| {
+                egui::Area::new("main")
+                    .anchor(egui::Align2::LEFT_TOP, (10.0, 10.0))
+                    .show(ctx, |_ui| {});
                 data.egui_shell.render(ctx, config_tx);
             },
             Rectangle::from_loc_and_size((0, 0), size.to_logical(scale)),

--- a/src/output_manager/output.rs
+++ b/src/output_manager/output.rs
@@ -92,7 +92,8 @@ impl Output {
         output.change_current_state(Some(mode), Some(transform), None, None);
         output.set_preferred(mode);
 
-        let egui = EguiState::new();
+        let mut egui = EguiState::new();
+        egui.set_zindex(0);
         let mut visuals = egui::style::Visuals {
             window_corner_radius: 0.0,
             ..Default::default()
@@ -167,7 +168,6 @@ impl Output {
             1.0,
             start_time,
             *modifiers,
-            0,
         )
     }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -45,7 +45,7 @@ use crate::{
 
 pub struct InputState {
     pub pointer_location: Point<f64, Logical>,
-    pub old_pointer_location: Point<f64, Logical>,
+    pub previous_pointer_location: Point<f64, Logical>,
     pub pointer: PointerHandle,
 
     pub keyboard: KeyboardHandle,
@@ -271,7 +271,7 @@ impl Anodium {
 
                 input_state: InputState {
                     pointer_location: (0.0, 0.0).into(),
-                    old_pointer_location: (0.0, 0.0).into(),
+                    previous_pointer_location: (0.0, 0.0).into(),
                     pointer,
                     keyboard,
                     modifiers_state: Default::default(),
@@ -388,10 +388,10 @@ impl Anodium {
                 elems.push(Box::new(PointerElement::new(
                     texture.clone(),
                     relative_location,
-                    self.input_state.pointer_location != self.input_state.old_pointer_location,
+                    self.input_state.pointer_location != self.input_state.previous_pointer_location,
                 )));
             }
-            self.input_state.old_pointer_location = self.input_state.pointer_location;
+            self.input_state.previous_pointer_location = self.input_state.pointer_location;
 
             if let Some(wl_dnd) = self.prepare_dnd_element(output_geometry.loc) {
                 elems.push(Box::new(wl_dnd));

--- a/src/state.rs
+++ b/src/state.rs
@@ -45,6 +45,7 @@ use crate::{
 
 pub struct InputState {
     pub pointer_location: Point<f64, Logical>,
+    pub old_pointer_location: Point<f64, Logical>,
     pub pointer: PointerHandle,
 
     pub keyboard: KeyboardHandle,
@@ -270,6 +271,7 @@ impl Anodium {
 
                 input_state: InputState {
                     pointer_location: (0.0, 0.0).into(),
+                    old_pointer_location: (0.0, 0.0).into(),
                     pointer,
                     keyboard,
                     modifiers_state: Default::default(),
@@ -386,8 +388,10 @@ impl Anodium {
                 elems.push(Box::new(PointerElement::new(
                     texture.clone(),
                     relative_location,
+                    self.input_state.pointer_location != self.input_state.old_pointer_location,
                 )));
             }
+            self.input_state.old_pointer_location = self.input_state.pointer_location;
 
             if let Some(wl_dnd) = self.prepare_dnd_element(output_geometry.loc) {
                 elems.push(Box::new(wl_dnd));
@@ -399,11 +403,9 @@ impl Anodium {
             .render_output(renderer, output, age, [0.1, 0.1, 0.1, 1.0], &elems)
             .unwrap();
 
-        if let Some(render_result) = render_result {
-            if !render_result.is_empty() {
-                #[cfg(feature = "debug")]
-                output.tick_fps();
-            }
+        if render_result.is_some() {
+            #[cfg(feature = "debug")]
+            output.tick_fps();
         }
 
         Ok(())


### PR DESCRIPTION
This PR add simple damage tracking to PointerElement by comparing pointer_location with previous_pointer_location.
If they are equal no damage is reported from PointerElement.
Also adds some small egui fixes:
- when render_result is Some([]) that means damage tracking for reseted (for example from buffer age reset), so we tick FPS then too
- removes shadows from egui elements
